### PR TITLE
Change to material icon

### DIFF
--- a/io-package.json
+++ b/io-package.json
@@ -84,7 +84,7 @@
                 "ru": "Cцeны"
             },
             "singleton": true,
-            "fa-icon": "fa-film"
+            "fa-icon": "theaters"
         }
     },
     "native": {},


### PR DESCRIPTION
Remnants of the FontAwesome have been eliminated. Added materialize icons for tab.